### PR TITLE
SDK constraints is determined in pubspec.yaml.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,3 +5,5 @@ description: Efficient implementation of a bitset.
 homepage: https://github.com/skalkin/bit_set
 dev_dependencies:
   test: any
+environment:
+  sdk: ">= 2.0.0 < 3.0.0"


### PR DESCRIPTION
Building of project is failed for updating Dart to version above 2.0. Adding SDK constraints in pubspec.yaml solved it.